### PR TITLE
Do not calculate the length of the IEND element

### DIFF
--- a/src/main/resources/com/mitre/png/xsd/png.dfdl.xsd
+++ b/src/main/resources/com/mitre/png/xsd/png.dfdl.xsd
@@ -54,7 +54,7 @@
 				     if (fn:exists(../IHDR)) then dfdl:valueLength(../IHDR, 'bytes')
 				else if (fn:exists(../PLTE)) then fn:count(../PLTE/Entry) * 3
 				else if (fn:exists(../IDAT)) then dfdl:valueLength(../IDAT/Data, 'bytes')
-				else if (fn:exists(../IEND)) then dfdl:valueLength(../IEND, 'bytes')
+				else if (fn:exists(../IEND)) then 0
 				else if (fn:exists(../cHRM)) then 32
 				else if (fn:exists(../gAMA)) then dfdl:valueLength(../gAMA/Image_Gamma, 'bytes')
 				else if (fn:exists(../iCCP)) then dfdl:valueLength(../iCCP/Profile_Name, 'bytes') + dfdl:valueLength(../iCCP/Compressed_Profile, 'bytes') + 2


### PR DESCRIPTION
Due to changes in Daffodil's alignment algorithm, we get stuck in a
deadlock when trying to calculate the length of the IEND element when
unparser. However, the length of IEND is always zero, so we can just
hardcode a zero for the output value calc rather than trying to figure
it out, which avoids the deadlock.